### PR TITLE
InfiniteScroll 컴포넌트를 분리하고 hook을 만들어서 파일 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import InfiniteScroll from './InfiniteScroll';
+
+export default function App () {
+  return <InfiniteScroll />;
+};

--- a/src/InfiniteScroll.jsx
+++ b/src/InfiniteScroll.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
+import useInfiniteScroll from './useInfiniteScroll';
 import styled from 'styled-components';
 
 const ListArea = styled.div`
@@ -27,8 +28,7 @@ const Sentinel = styled.div`
   height: 1px;
 `;
 
-const ListBox = () => {
-  const ref = useRef();
+export default function InfiniteScroll() {
   const listNum = useRef(1);
   const [list, setList] = useState([]);
 
@@ -37,35 +37,23 @@ const ListBox = () => {
     setList(nextList);
   }, [list]);
 
-  const Lists = list.map((num, index) => {
-      return (
-        <List key={index}>
-          {num}
-        </List>
-      );
-    });
-
   const checkIntersect = useCallback(([entry], observer) => {
     if (entry.isIntersecting) {
       observer.unobserve(entry.target);
-      //redux dispatch
       onInsert();
       observer.observe(entry.target);
     }
   }, [onInsert]);
 
-  useEffect(() => {
-    let observer;
-    if (ref.current) {
-      observer = new IntersectionObserver(checkIntersect, {
-        root: null,
-        rootMargin: '0px',
-        threshold: 0.5,
-      });
-      observer.observe(ref.current);
-    }
-    return () => observer && observer.disconnect();
-  }, [checkIntersect]);
+  const { ref } = useInfiniteScroll(checkIntersect);
+
+  const Lists = list.map((num, index) => {
+    return (
+      <List key={index}>
+        {num}
+      </List>
+    );
+  });
 
   return (
     <ListArea className="scroll-control">
@@ -74,5 +62,3 @@ const ListBox = () => {
     </ListArea>
   );
 };
-
-export default ListBox;

--- a/src/useInfiniteScroll.js
+++ b/src/useInfiniteScroll.js
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+function useInfiniteScroll(checkIntersect) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    let observer;
+    if (ref.current) {
+      observer = new IntersectionObserver(checkIntersect, {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.5,
+      });
+      observer.observe(ref.current);
+    }
+    return () => observer && observer.disconnect();
+  }, [checkIntersect]);
+
+  return { ref };
+}
+
+export default useInfiniteScroll;


### PR DESCRIPTION
- InfiniteScroll 컴포넌트를 App에서 분리하였습니다.
- 무한 스크롤 관찰 요소(element)를 리턴하는 useInfiniteScroll hook을 만들어서 재사용이 가능하도록 만들었습니다.